### PR TITLE
Asynchronous method return value changed to Single

### DIFF
--- a/Sources/RxHttpClient/RxHttpClient.swift
+++ b/Sources/RxHttpClient/RxHttpClient.swift
@@ -57,7 +57,7 @@ public protocol Request {
 
     func header(name: String, value: String) -> Request
 
-    func execute() -> Observable<Response>
+    func execute() -> Single<Response>
 }
 
 public protocol GetPathExtensible {


### PR DESCRIPTION
Because it's clear that the event will occur only once.